### PR TITLE
feat(api): añadir DTOs de solicitud

### DIFF
--- a/docs/change-analysis.md
+++ b/docs/change-analysis.md
@@ -1,18 +1,21 @@
 # Change Analysis - Reopen and History
 
-1. **¿Qué métodos del dominio se ven afectados?**
+1. ¿Qué métodos del dominio se ven afectados?
    - El constructor (para inicializar el historial con ABIERTA).
-   - `iniciarProceso()` y `cerrar()` (deben registrar el cambio en el historial).
-   - Nuevo método: `reabrir()`.
+   - 'iniciarProceso()' y 'cerrar()'  (deben registrar el cambio en el historial).
+   - Nuevo método: 'reabrir()'.
 
-2. **¿Qué reglas actuales cambian?**
-   - Antes `CERRADA` era un estado final. Ahora, desde `CERRADA` se permite la transición hacia `EN_PROCESO`.
+2. ¿Qué reglas actuales cambian?
+   - Antes 'CERRADA' era un estado final. Ahora, desde 'CERRADA' se permite la transición hacia 'EN_PROCESO'.
 
-3. **¿Qué tests deberían romperse?**
-   - En teoría, ninguno de los anteriores debería romperse si añadimos el historial como una extensión pasiva. Romperíamos tests si alteramos las reglas de `cerrar()` o `asignarTecnico()`, pero no es el caso.
+3. ¿Qué tests deberían romperse?
+   - En teoría, ninguno de los anteriores debería romperse si añadimos el historial como una extensión pasiva. 			Romperíamos tests si alteramos las reglas de 'cerrar()' o 'asignarTecnico()'.
 
-4. **¿Qué parte del modelo debe extenderse?**
-   - La entidad de dominio `Solicitud` necesitará un atributo `List<Estado> historialEstados`. He decidido usar una lista del Enum `Estado` (Value Object interno) porque es simple, expresivo y evita crear una entidad separada innecesaria por ahora.
+4. ¿Qué parte del modelo debe extenderse?
+   - La entidad 'Solicitud necesitará un atributo 'List<Estado> historialEstados'. se ha decidido usar una lista 		de Enum 'Estado' porque es simple, expresivo y evita crear una entidad separada innecesaria.
 
-5. **¿Qué impacto tiene en persistencia?**
-   - `SolicitudEntity` requerirá una colección mapeada con `@ElementCollection` para guardar la lista de Enums en una tabla secundaria automática.
+5. ¿Qué impacto tiene en persistencia?
+   - 'SolicitudEntity' requerirá una colección mapeada con '@ElementCollection' para guardar la lista de Enums
+    		en una tabla secundaria automática.
+   
+  

--- a/docs/refactor-notes.md
+++ b/docs/refactor-notes.md
@@ -1,22 +1,44 @@
-# Notas de Refactorización - Sesión 8
+# Notas de Refactorización - Sesion 8
 
 ## Problema 1: Excepciones Genéricas e Inconsistencia en Tests
-1. **Problema identificado:** Uso de `IllegalArgumentException` e `IllegalStateException` genéricos en la lógica de dominio (`Solicitud`) y servicios (`SolicitudService`). Inconsistencia en los tests al atrapar estas excepciones genéricas (se usa `RuntimeException` en un lado y `IllegalArgumentException` en otro).
-2. **Métrica asociada:** Code Smells (Manejo de errores genérico), Maintainability Rating.
-3. **Riesgo potencial si no se corrige:** Dificulta el manejo de errores en capas superiores (como controladores REST, que no sabrán si un `IllegalArgumentException` es por un 404 Not Found o un 400 Bad Request). Los tests son frágiles y confusos.
+
+1. **Problema identificado:** 
+
+Uso de `IllegalArgumentException` e `IllegalStateException` genéricos en la lógica de dominio (`Solicitud`) y servicios (`SolicitudService`). Inconsistencia en los tests al atrapar estas excepciones genéricas (se usa `RuntimeException` en un lado y `IllegalArgumentException` en otro).
+
+2. **Métrica asociada:** 
+Code Smells (Manejo de errores genérico), Maintainability Rating.
+
+3. **Riesgo potencial si no se corrige:** 
+Dificulta el manejo de errores en capas superiores (como controladores REST, que no sabrán si un `IllegalArgumentException` es por un 404 Not Found o un 400 Bad Request). Los tests son frágiles y confusos.
+
 
 ## Problema 2: Código Muerto (Speculative Generality)
-1. **Problema identificado:** La clase `Cliente.java` está vacía, no se utiliza en ninguna parte del dominio y requiere configuración extra en el `pom.xml` para no arruinar la cobertura.
-2. **Métrica asociada:** Code Smells (Dead code), Technical Debt.
-3. **Riesgo potencial si no se corrige:** Aumenta la carga cognitiva al leer el proyecto y ensucia las métricas de cobertura reales.
+
+1. **Problema identificado:** 
+La clase `Cliente.java` está vacía, no se utiliza en ninguna parte del dominio y requiere configuración extra en el `pom.xml` para no arruinar la cobertura.
+
+2. **Métrica asociada:** 
+Code Smells (Dead code), Technical Debt.
+
+3. **Riesgo potencial si no se corrige:** 
+Aumenta la carga cognitiva al leer el proyecto y ensucia las métricas de cobertura reales.
+
+
 
 ## Resultados tras la refactorización
 
-1. **Qué métrica mejoró:** - Se eliminó el Code Smell de "Dead Code" (Clase vacía).
-   - Se redujo el acoplamiento y se mejoró el "Maintainability Rating" al sustituir excepciones genéricas de Java por excepciones de dominio (Domain Exceptions).
+1. **Qué métrica mejoró:** 
+
+- Se eliminó el Code Smell de "Dead Code" (Clase vacía).
+   - Se redujo el acoplamiento y se mejoró el "Maintainability Rating" al sustituir excepciones genéricas de Java 	 por excepciones de dominio (Domain Exceptions).
    - Se limpió el POM, eliminando exclusiones innecesarias de JaCoCo.
-2. **Qué técnica de refactor se aplicó:** - Remove Dead Code.
+   
+2. **Qué técnica de refactor se aplicó:** 
+   - Remove Dead Code.
    - Replace Exception with Custom Domain Exception (mejora de semántica).
    - Estandarización de assertions en los Tests.
-3. **Qué beneficio aporta a mantenimiento futuro:** - Ahora, si exponemos nuestra API mediante controladores REST, podemos tener un `@ControllerAdvice` que capture `EntidadNoEncontradaException` y devuelva un 404 (Not Found) automáticamente, y capture `ReglaNegocioException` para devolver un 400 (Bad Request). Con excepciones genéricas, esto habría sido imposible de distinguir. 
+   
+3. **Qué beneficio aporta a mantenimiento futuro:** 
+- Ahora, si exponemos nuestra API mediante controladores REST, podemos tener un `@ControllerAdvice` que capture `EntidadNoEncontradaException` y devuelva un 404 (Not Found) automáticamente, y capture `ReglaNegocioException` para devolver un 400 (Bad Request). Con excepciones genéricas, esto habría sido imposible de distinguir. 
    - La eliminación de código muerto reduce la confusión de futuros desarrolladores al explorar el paquete de dominio.

--- a/src/main/java/com/mgcss/api/dto/AsignarTecnicoRequestDTO.java
+++ b/src/main/java/com/mgcss/api/dto/AsignarTecnicoRequestDTO.java
@@ -1,0 +1,9 @@
+package com.mgcss.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AsignarTecnicoRequestDTO(
+    @NotNull(message = "El ID del técnico no puede ser nulo")
+    Long tecnicoId
+) {
+}

--- a/src/main/java/com/mgcss/api/dto/SolicitudRequestDTO.java
+++ b/src/main/java/com/mgcss/api/dto/SolicitudRequestDTO.java
@@ -1,0 +1,8 @@
+package com.mgcss.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+
+public record SolicitudRequestDTO(
+) {
+}

--- a/src/main/java/com/mgcss/api/dto/SolicitudResponseDTO.java
+++ b/src/main/java/com/mgcss/api/dto/SolicitudResponseDTO.java
@@ -1,0 +1,13 @@
+package com.mgcss.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record SolicitudResponseDTO(
+    long id,
+    String estado,
+    LocalDate fechaCreacion,
+    Long tecnicoId, 
+    List<String> historial 
+) {
+}

--- a/src/main/java/com/mgcss/infraestructure/SolicitudRepository.java
+++ b/src/main/java/com/mgcss/infraestructure/SolicitudRepository.java
@@ -1,5 +1,6 @@
 package com.mgcss.infraestructure;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.mgcss.domain.Solicitud;
@@ -7,4 +8,5 @@ import com.mgcss.domain.Solicitud;
 public interface SolicitudRepository {
     Solicitud save(Solicitud solicitud);
     Optional<Solicitud> findById(Long id);
+    List<Solicitud> findAll();
 }

--- a/src/main/java/com/mgcss/service/SolicitudService.java
+++ b/src/main/java/com/mgcss/service/SolicitudService.java
@@ -2,30 +2,48 @@ package com.mgcss.service;
 
 import com.mgcss.domain.*;
 import com.mgcss.infraestructure.SolicitudRepository;
-
-
+import java.util.List;
 
 public class SolicitudService {
     private final SolicitudRepository solicitudRepo;
     private final TecnicoRepository tecnicoRepo;
 
-    // Inyección por constructor: clave para la testeabilidad
     public SolicitudService(SolicitudRepository solicitudRepo, TecnicoRepository tecnicoRepo) {
         this.solicitudRepo = solicitudRepo;
         this.tecnicoRepo = tecnicoRepo;
     }
 
+    public Solicitud crearSolicitud() {
+    	Solicitud  solicitud = new Solicitud();
+    	return solicitudRepo.save(solicitud);
+    }
+    
+    public Solicitud consultarSolicitud(long id) {
+    	return solicitudRepo.findById(id)
+    			.orElseThrow(() -> new EntidadNoEncontrada("Solicitud no encontrada"));
+    }
+
+    public List<Solicitud> listarSolicitudes(){
+    	return solicitudRepo.findAll();
+    }
+    
+    public void CambiarEstado(Long id) {
+        Solicitud solicitud = consultarSolicitud(id);
+        solicitud.iniciarProceso();
+        solicitudRepo.save(solicitud);
+    }
+    
+    public void reabrirSolicitud(Long id) {
+        Solicitud solicitud = consultarSolicitud(id);
+        solicitud.reabrir();
+        solicitudRepo.save(solicitud);
+    }  
     public void asignarTecnico(Long solicitudId, Long tecnicoId) {
-        // Orquestación: Obtener de infra, decidir en dominio, guardar en infra
         Solicitud solicitud = solicitudRepo.findById(solicitudId)
                 .orElseThrow(() -> new EntidadNoEncontrada("Solicitud no encontrada"));
-        
         Tecnico tecnico = tecnicoRepo.findById(tecnicoId)
                 .orElseThrow(() -> new EntidadNoEncontrada("Técnico no encontrado"));
-
-        // Delegación al dominio 
-        solicitud.asignarTecnico(tecnico);
-        
+        solicitud.asignarTecnico(tecnico);        
         solicitudRepo.save(solicitud);
     }
 }

--- a/src/test/java/com/mgcss/api/dto/testSolicitudResponseDTO.java
+++ b/src/test/java/com/mgcss/api/dto/testSolicitudResponseDTO.java
@@ -1,0 +1,35 @@
+package com.mgcss.api.dto;
+
+import org.junit.jupiter.api.Test;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DtoTest {
+
+    @Test
+    void testSolicitudResponseDTO() {
+        List<String> historial = List.of("ABIERTA", "EN_PROCESO");
+        SolicitudResponseDTO dto = new SolicitudResponseDTO(1L, "EN_PROCESO", LocalDate.now(), 99L, historial);
+
+        // Llamamos a los getters para asegurar que se cubren en el análisis
+        assertEquals(1L, dto.id());
+        assertEquals("EN_PROCESO", dto.estado());
+        assertNotNull(dto.fechaCreacion());
+        assertEquals(99L, dto.tecnicoId());
+        assertEquals(2, dto.historial().size());
+    }
+
+    @Test
+    void testAsignarTecnicoRequestDTO() {
+        AsignarTecnicoRequestDTO dto = new AsignarTecnicoRequestDTO(99L);
+        assertEquals(99L, dto.tecnicoId());
+    }
+
+    @Test
+    void testSolicitudRequestDTO() {
+        SolicitudRequestDTO dto = new SolicitudRequestDTO();
+        assertNotNull(dto);
+    }
+}

--- a/src/test/java/com/mgcss/service/SolicitudServiceTest.java
+++ b/src/test/java/com/mgcss/service/SolicitudServiceTest.java
@@ -4,61 +4,116 @@ import com.mgcss.domain.EntidadNoEncontrada;
 import com.mgcss.domain.Solicitud;
 import com.mgcss.domain.Tecnico;
 import com.mgcss.domain.TecnicoRepository;
-import com.mgcss.infraestructure.*;
+import com.mgcss.infraestructure.SolicitudRepository;
 import org.junit.jupiter.api.Test;
-import java.util.Optional;
-import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
 class SolicitudServiceTest {
 
-	 @Test
-	    void debeAsignarTecnicoCorrectamente() {
+    @Mock
+    private SolicitudRepository repoSolicitud;
 
-	        SolicitudRepository repoSolicitud = mock(SolicitudRepository.class);
-	        TecnicoRepository repoTecnico = mock(TecnicoRepository.class);
+    @Mock
+    private TecnicoRepository repoTecnico;
 
-	        SolicitudService service = new SolicitudService(repoSolicitud, repoTecnico);
+    @InjectMocks
+    private SolicitudService service;
 
-	        Solicitud solicitud = new Solicitud();
-	        Tecnico tecnicoActivo = new Tecnico(true);
+    @Test
+    void debeCrearSolicitud() {
+        Solicitud nueva = new Solicitud();
+        when(repoSolicitud.save(any(Solicitud.class))).thenReturn(nueva);
 
-	        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
-	        when(repoTecnico.findById(99L)).thenReturn(Optional.of(tecnicoActivo));
+        Solicitud resultado = service.crearSolicitud();
 
-	        service.asignarTecnico(1L, 99L);
+        assertNotNull(resultado);
+        verify(repoSolicitud).save(any(Solicitud.class));
+    }
 
-	        verify(repoSolicitud).save(solicitud);
+    @Test
+    void debeConsultarSolicitudExistente() {
+        Solicitud solicitud = new Solicitud();
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
 
-	        assertEquals(tecnicoActivo, solicitud.getTecnico());
-	    }
-	 @Test
-	    void debeLanzarExcepcionSiSolicitudNoExiste() {
+        Solicitud resultado = service.consultarSolicitud(1L);
 
-	        SolicitudRepository repoSolicitud = mock(SolicitudRepository.class);
-	        TecnicoRepository repoTecnico = mock(TecnicoRepository.class);
+        assertNotNull(resultado);
+        assertEquals(solicitud, resultado);
+    }
 
-	        when(repoSolicitud.findById(1L)).thenReturn(Optional.empty());
+    @Test
+    void debeLanzarExcepcionAlConsultarSolicitudQueNoExiste() {
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.empty());
+        assertThrows(EntidadNoEncontrada.class, () -> service.consultarSolicitud(1L));
+    }
 
-	        SolicitudService service = new SolicitudService(repoSolicitud, repoTecnico);
+    @Test
+    void debeListarSolicitudes() {
+        List<Solicitud> listaMock = Arrays.asList(new Solicitud(), new Solicitud());
+        when(repoSolicitud.findAll()).thenReturn(listaMock);
 
-	        assertThrows(EntidadNoEncontrada.class, () -> {
-	            service.asignarTecnico(1L, 99L);
-	        });
-	    }
-	 
-	 @Test
-	    void debeLanzarExcepcionSiTecnicoNoExiste() {
-	        SolicitudRepository repoSolicitud = mock(SolicitudRepository.class);
-	        TecnicoRepository repoTecnico = mock(TecnicoRepository.class);
-	        SolicitudService service = new SolicitudService(repoSolicitud, repoTecnico);
+        List<Solicitud> resultado = service.listarSolicitudes();
 
-	        Solicitud solicitud = new Solicitud();
-	        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
-	        when(repoTecnico.findById(99L)).thenReturn(Optional.empty());
+        assertEquals(2, resultado.size());
+        verify(repoSolicitud).findAll();
+    }
 
-	        assertThrows(EntidadNoEncontrada.class, () -> {
-	            service.asignarTecnico(1L, 99L);
-	        });
-	    }
+    @Test
+    void debeIniciarProcesoSolicitud() {
+        Solicitud solicitud = new Solicitud();
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
+
+        service.CambiarEstado(1L);
+
+        assertEquals(Solicitud.Estado.EN_PROCESO, solicitud.getEstado());
+        verify(repoSolicitud).save(solicitud);
+    }
+
+
+    @Test
+    void debeReabrirSolicitud() {
+        Solicitud solicitud = new Solicitud();
+        solicitud.iniciarProceso();
+        solicitud.cerrar(); 
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
+
+        service.reabrirSolicitud(1L);
+
+        assertEquals(Solicitud.Estado.EN_PROCESO, solicitud.getEstado());
+        verify(repoSolicitud).save(solicitud);
+    }
+
+    @Test
+    void debeAsignarTecnicoCorrectamente() {
+        Solicitud solicitud = new Solicitud();
+        Tecnico tecnicoActivo = new Tecnico(true);
+
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
+        when(repoTecnico.findById(99L)).thenReturn(Optional.of(tecnicoActivo));
+
+        service.asignarTecnico(1L, 99L);
+
+        verify(repoSolicitud).save(solicitud);
+        assertEquals(tecnicoActivo, solicitud.getTecnico());
+    }
+
+    @Test
+    void debeLanzarExcepcionSiTecnicoNoExisteAlAsignar() {
+        Solicitud solicitud = new Solicitud();
+        when(repoSolicitud.findById(1L)).thenReturn(Optional.of(solicitud));
+        when(repoTecnico.findById(99L)).thenReturn(Optional.empty());
+
+        assertThrows(EntidadNoEncontrada.class, () -> service.asignarTecnico(1L, 99L));
+    }
 }


### PR DESCRIPTION
- Añadido findAll() en SolicitudRepository.
- Se  ha implementado los métodos para todos los endpoints obligatorios en SolicitudService.
- Se ha creadp SolicitudRequestDTO, SolicitudResponseDTO y AsignarTecnicoRequestDTO como Java Records para proteger el dominio.